### PR TITLE
Fix typo

### DIFF
--- a/howto-user-management.md
+++ b/howto-user-management.md
@@ -52,7 +52,7 @@ When a user in a group creates a resource in a database, like a table, all users
 
 ## Users created through the CLI and the API
 
-Users that you create through the Cloud Databases API and the Cloud Databases CLI will also be members of `ibm-cloud-database-base-user`. They are able to log in, create users, and create databases.
+Users that you create through the Cloud Databases API and the Cloud Databases CLI will also be members of `ibm-cloud-base-user`. They are able to log in, create users, and create databases.
 
 When a user creates a resource in a database, like a table, all users that are in the same group have access to that resource.  Resources created by any of the users in `ibm-cloud-base-user` are accessible to other users in `ibm-cloud-base-user`, including the admin user.
 


### PR DESCRIPTION
`ibm-cloud-database-base-user` seems to be a typo for `ibm-cloud-base-user`